### PR TITLE
really basic rspec tests for google auth

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,6 @@
 class SessionsController < ApplicationController
   def create
-    user = User.from_omniauth(env['omniauth.auth'])
+    user = User.from_omniauth(request.env['omniauth.auth'])
     session[:user_id] = user.id
     redirect_to root_path
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,18 +1,45 @@
 require 'rails_helper'
 
-RSpec.describe SessionsController, type: :controller do
+describe SessionsController do
+  before :all do
+    OmniAuth.config.test_mode = true
+
+    OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new({
+      :provider => 'google_oauth2', 
+      :uid => '113792992188462614663',
+      :info => {
+        :name => 'John Doe',
+        :email => 'john@company.com',
+        :first_name => 'John',
+        :last_name => 'Doe'
+      },
+      :credentials => {
+        :token => 'token',
+        :refresh_token => 'another_token',
+        :expires_at => 1234567890,
+        :expires => true
+      }
+    })
+  end
+
+
+  before :each do
+    request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:google]
+  end
 
   describe "GET #create" do
     it "returns http success" do
+      session[:user_id].should be nil
       get :create
-      expect(response).to have_http_status(:success)
+      session[:user_id].should_not be nil
+      response.should redirect_to root_url
     end
   end
 
   describe "GET #destroy" do
     it "returns http success" do
       get :destroy
-      expect(response).to have_http_status(:success)
+      response.should redirect_to root_url
     end
   end
 


### PR DESCRIPTION
@DerekStride please review
- the mocks for auth should ideally belong somewhere other than the before
- had to replace `User.from_omniauth(env['omniauth.auth'])` with `User.from_omniauth(request.env['omniauth.auth'])` for some reason to make this work. It doesn't seem to affect typical usage though.
