### PR TITLE
minimal RSpec test of CompetencyController using FactoryGirl

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,10 @@ group :development, :test do
   gem 'rspec-rails'
 end
 
+group :test do
+  gem "factory_girl_rails"
+end
+
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,11 @@ GEM
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.6.0)
+    factory_girl (4.5.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.6.0)
+      factory_girl (~> 4.5.0)
+      railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     globalid (0.3.6)
@@ -193,6 +198,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   coffee-rails (~> 4.1.0)
+  factory_girl_rails
   jbuilder (~> 2.0)
   jquery-rails
   omniauth-google-oauth2 (~> 0.3.1)

--- a/app/controllers/competencies_controller.rb
+++ b/app/controllers/competencies_controller.rb
@@ -4,7 +4,8 @@ class CompetenciesController < ApplicationController
   # GET /competencies
   # GET /competencies.json
   def index
-    @competencies = Competency.all
+    #@competencies = Competency.all
+    render json: Competency.all
   end
 
   # GET /competencies/1

--- a/spec/controllers/competencies_controller_spec.rb
+++ b/spec/controllers/competencies_controller_spec.rb
@@ -8,6 +8,16 @@ RSpec.describe CompetenciesController, type: :controller do
       expect(response).to have_http_status(200)
     end
 
+    it "returns all the competencies" do
+      FactoryGirl.create :competency
+      FactoryGirl.create :competency, name: "Can juggle"
+      get :index
+      body = JSON.parse(response.body)
+      competency_names = body.map { |c| c["name"]}
+
+      expect(competency_names).to match_array(["Nginx", "Can juggle"])
+    end
+
   end
 
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+    factory :competency do
+        name "Nginx"
+    end
+end


### PR DESCRIPTION
(trying this again, this time without my weird merges that brought back old stuff)

Just the barebones initial set up for testing our controllers using RSpec and FactoryGirl (need to run bundle install). The FactoryGirl fixtures live in the spec/factories.rb file.

To make my only CompetencyController test pass, I had to render json in the index action. Not sure if that's the right thing to do? @DerekStride Please review!

I also noticed some leftover "learnable" mentions in the private "add_competencies" method... Will try to write a failing test to expose them!
