### PR TITLE
added needed responder gem, and tested and fixed show controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 
 gem 'omniauth-google-oauth2', '~> 0.3.1'
 
+gem 'responders', '~> 2.0'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,8 @@ GEM
     rake (11.1.2)
     rdoc (4.2.2)
       json (~> 1.4)
+    responders (2.1.2)
+      railties (>= 4.2.0, < 5.1)
     rspec-core (3.4.4)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
@@ -206,6 +208,7 @@ DEPENDENCIES
   pg
   pry
   rails (= 4.2.5.2)
+  responders (~> 2.0)
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/app/controllers/competencies_controller.rb
+++ b/app/controllers/competencies_controller.rb
@@ -1,4 +1,5 @@
 class CompetenciesController < ApplicationController
+  respond_to :html, :json
   before_action :set_competency, only: [:show, :edit, :update, :destroy]
   before_action :ensure_params, only: [:create]
 
@@ -12,14 +13,7 @@ class CompetenciesController < ApplicationController
   # GET /competencies/1
   # GET /competencies/1.json
   def show
-    respond_with @competency do |format|
-      format.json do
-        render json: {}, status: :ok
-      end
-      format.html do
-        redirect_to @competency
-      end
-    end
+    render json: Competency.find(params[:id])
   end
 
   # GET /competencies/new

--- a/spec/controllers/competencies_controller_spec.rb
+++ b/spec/controllers/competencies_controller_spec.rb
@@ -21,7 +21,16 @@ RSpec.describe CompetenciesController, type: :controller do
 
       expect(competency_names).to match_array(["Can solve Rubik's cube", "Can juggle"])
     end
+  end
 
+  describe "GET /competencies/:id" do
+  	it "returns a requested competency" do
+  	  get :show, id: Competency.last.id
+  	  expect(response).to be_success
+  	  body = JSON.parse(response.body)
+
+      expect(body["name"]).to eq "Can solve Rubik's cube"
+    end
   end
 
   describe "POST /competencies" do


### PR DESCRIPTION
@DerekStride please review
Some of our basic API calls are still failing. Part of the issue is that responders have been moved to a gem in a recent rails update. I added the gem, but also restricted the call to the "show" controller to just render JSON. This solves one of the problems, but there's probably many more.
